### PR TITLE
Absorb the derivative of the mapping into the quadrature weights.

### DIFF
--- a/grid_methods/pseudospectral_grids/gauss_legendre_lobatto.py
+++ b/grid_methods/pseudospectral_grids/gauss_legendre_lobatto.py
@@ -49,7 +49,7 @@ class GaussLegendreLobatto:
         self.PN_x = legendre.legval(self.x[1:-1], c)
         self.PN_x2 = legendre.legval(self.x, c)
 
-        self.weights = 2 / (N * (N + 1))
+        self.weights = 2 / (N * (N + 1)) * np.ones(N + 1)
         if not symmetrize:
             self.weights /= self.PN_x2**2
 

--- a/grid_methods/pseudospectral_grids/gauss_legendre_lobatto.py
+++ b/grid_methods/pseudospectral_grids/gauss_legendre_lobatto.py
@@ -55,6 +55,7 @@ class GaussLegendreLobatto:
 
         self.r = Mapping.r_x(self.x)
         self.r_dot = Mapping.dr_dx(self.x)
+        self.weights *= self.r_dot
 
         for i in range(N + 1):
             for j in range(N + 1):

--- a/grid_methods/spherical_coordinates/radial_matrix_elements.py
+++ b/grid_methods/spherical_coordinates/radial_matrix_elements.py
@@ -13,4 +13,4 @@ class RadialMatrixElements:
         self.D1 = gll.D1[1:-1, 1:-1]
         self.D2 = gll.D2[1:-1, 1:-1]
         self.nr = len(self.r)
-        self.weights = gll.weights
+        self.weights = gll.weights[1:-1]

--- a/grid_methods/spherical_coordinates/radial_poisson.py
+++ b/grid_methods/spherical_coordinates/radial_poisson.py
@@ -58,8 +58,7 @@ def solve_radial_Poisson_dvr(GLL, n_L):
     r = GLL.r[1:-1]
     w_r = GLL.weights[1:-1]
     r_dot = GLL.r_dot[1:-1]
-    D1 = GLL.D1
-    D2 = np.dot(D1, D1)[1:-1, 1:-1]
+    D2 = GLL.D2[1:-1, 1:-1]
 
     n_r = len(r)
     tilde_vL = np.zeros((n_L, n_r, n_r))
@@ -75,7 +74,7 @@ def solve_radial_Poisson_dvr(GLL, n_L):
         tilde_vL_hom = np.zeros((n_r, n_r))
         for a in range(n_r):
             tilde_vL_hom[:, a] = (
-                r_dot * r[a] ** L * w_r[a] / r_max ** (2 * L + 1)
+                r[a] ** L * w_r[a] / r_max ** (2 * L + 1)
             ) * r ** (L + 1)
 
         tilde_vL[L] = tilde_vL_inhom + tilde_vL_hom

--- a/tests/test_eigenstates.py
+++ b/tests/test_eigenstates.py
@@ -38,12 +38,12 @@ def test_particle_in_box():
         for k in range(1, N_max):
             eps_k_approx = eps[k - 1]
             psi_k_approx = U[:, k - 1]
-            norm_psi_k_approx = np.dot(w, x_dot * psi_k_approx**2)
+            norm_psi_k_approx = np.dot(w, psi_k_approx**2)
             psi_k_approx /= np.sqrt(norm_psi_k_approx)
 
             eps_k_exact = k**2 * np.pi**2 / (2 * L**2)
             psi_k_exact = np.sqrt(2 / L) * np.sin(k * np.pi * x / L)
-            norm_psi_k_exact = np.dot(w, x_dot * psi_k_exact**2)
+            norm_psi_k_exact = np.dot(w, psi_k_exact**2)
             np.testing.assert_allclose(
                 eps_k_approx, eps_k_exact, rtol=0.0, atol=1e-12
             )
@@ -99,7 +99,7 @@ def test_harmonic_oscillator():
             eps_k_exact = omega * (k + 0.5)
 
             psi_k_approx = U[:, k]
-            norm_psi_k_approx = np.dot(w, x_dot * psi_k_approx**2)
+            norm_psi_k_approx = np.dot(w, psi_k_approx**2)
             psi_k_approx /= np.sqrt(norm_psi_k_approx)
 
             psi_k_exact = (
@@ -177,15 +177,15 @@ def test_hydrogenic_spherical_coordinates():
             u_n3_l = u_nl_exact(r, n3, l, Z)
 
             u_n1_l_approx = U[:, 0]
-            norm_u_n1_l_approx = np.dot(w, r_dot * u_n1_l_approx**2)
+            norm_u_n1_l_approx = np.dot(w, u_n1_l_approx**2)
             u_n1_l_approx /= np.sqrt(norm_u_n1_l_approx)
 
             u_n2_l_approx = U[:, 1]
-            norm_u_n2_l_approx = np.dot(w, r_dot * u_n2_l_approx**2)
+            norm_u_n2_l_approx = np.dot(w, u_n2_l_approx**2)
             u_n2_l_approx /= np.sqrt(norm_u_n2_l_approx)
 
             u_n3_l_approx = U[:, 2]
-            norm_u_n3_l_approx = np.dot(w, r_dot * u_n3_l_approx**2)
+            norm_u_n3_l_approx = np.dot(w, u_n3_l_approx**2)
             u_n3_l_approx /= np.sqrt(norm_u_n3_l_approx)
 
             np.testing.assert_allclose(

--- a/tests/test_quadrature.py
+++ b/tests/test_quadrature.py
@@ -44,7 +44,7 @@ def test_integrate_polynomials_mapped_interval():
         r_dot = GLL.r_dot
         a_tol = 1e-12
         for n in range(1, 2 * N):
-            integral_xn = np.dot(w, r_dot * GLL.r**n)
+            integral_xn = np.dot(w, GLL.r**n)
             np.testing.assert_allclose(
                 np.array([integral_xn]),
                 np.array([(b ** (n + 1) - a ** (n + 1)) / (n + 1)]),
@@ -84,7 +84,7 @@ def test_integrate_xk_exp_minus_a_x2():
 
         for k in range(6):
             f = x**k * np.exp(-a * x**2)
-            integral_quadrature = np.dot(w, x_dot * f)
+            integral_quadrature = np.dot(w, f)
             integral_exact = 0.5 * a ** (-(k + 1) / 2) * gamma((k + 1) / 2)
             np.testing.assert_allclose(
                 integral_quadrature, integral_exact, rtol=0.0, atol=1e-12

--- a/tests/test_radial_poisson.py
+++ b/tests/test_radial_poisson.py
@@ -47,7 +47,7 @@ def test_radial_poisson():
     r_dot = GLL.r_dot[1:-1]
 
     u_1s_gaussian = r * np.exp(-(r**2))
-    norm_psi = np.dot(w_r, r_dot * u_1s_gaussian**2)
+    norm_psi = np.dot(w_r, u_1s_gaussian**2)
     u_1s_gaussian /= np.sqrt(norm_psi)
 
     tilde_V0 = np.einsum(
@@ -65,7 +65,7 @@ def test_radial_poisson():
     assert np.max(np.abs(tilde_V0 - tilde_V0_exact_1s_gaussian)) < 1e-10
 
     u_1s = r * np.exp(-r)
-    norm_1s = np.dot(w_r, r_dot * u_1s**2)
+    norm_1s = np.dot(w_r, u_1s**2)
     u_1s /= np.sqrt(norm_1s)
     tilde_V0_1s = np.einsum(
         "b, ab, b->a", u_1s, tilde_V0_dvr[0], u_1s, optimize=True


### PR DESCRIPTION
When changing from the interval of the Legendre-Lobatto nodes to the "physical" interval by the mapping $r(x): [-1,1] \rightarrow [a,b]$, we have that integrals 
are computed by quadrature as

$$\int_a^b f(r(x)) dr = \int_{-1}^1 \dot{r}(x) f(r(x)) dx \approx \sum_{k=0}^N \dot{r}(x_k) w_k f(r(x_k).$$

Previously, we have had to keep track of the $\dot{r}(x_k)$-array. Instead, we now absorb the derivative of the mapping into the quadrature weights, that is, 

$$ w \rightarrow w \odot r(x),$$

where $\odot$ denotes the element-wise product of the arrays $w, r(x)$.