### PR TITLE
Support SciPy >= 1.15.0 compatibility for Spherical Harmonics

### DIFF
--- a/examples/stationary_states_magnetic.py
+++ b/examples/stationary_states_magnetic.py
@@ -1,6 +1,9 @@
 import numpy as np
 import time
 from matplotlib import pyplot as plt
+import scipy as sp
+
+print(f"Scipy version: {sp.__version__}")
 
 from grid_lib.pseudospectral_grids.gauss_legendre_lobatto import (
     GaussLegendreLobatto,
@@ -15,6 +18,8 @@ from grid_lib.spherical_coordinates.radial_matrix_elements import (
     RadialMatrixElements,
 )
 
+import grid_lib as gb
+print(f"Grid-lib version: {gb.__version__}")
 
 def kron_delta(x1, x2):
     if x1 == x2:
@@ -23,9 +28,9 @@ def kron_delta(x1, x2):
         return 0
 
 
-N = 100
-r_max = 20
-gll = GaussLegendreLobatto(N, Linear_map(r_max=r_max))
+N = 36
+r_max = 12
+gll = GaussLegendreLobatto(N, Linear_map(r_max=r_max), symmetrize=False)
 weights = gll.weights
 
 # setup radial matrix elements
@@ -33,12 +38,12 @@ radial_matrix_elements = RadialMatrixElements(gll)
 potential = -radial_matrix_elements.r_inv
 r = radial_matrix_elements.r
 n_r = len(r)
-D1 = radial_matrix_elements.D1
+
 T_D2 = -(1 / 2) * radial_matrix_elements.D2
 
 Z = 1
 B = 1
-l_max = 12
+l_max = 6
 m_list = [0, -1, -2]
 
 print()
@@ -82,11 +87,14 @@ for m in m_list:
                     col += 1
             row += 1
 
-    eps, C = np.linalg.eigh(H)
+    eps, C = np.linalg.eig(H)
+    idx = np.argsort(eps)
+    eps = eps[idx]
+    C = C[:, idx]
 
     # Print binding energy as defined in Ref.[1] and groundstate energy.
     # The resulting binding energies for m=0,-1,-2 and B=1.0 are in reasonable agreement with
     # the values reported in Ref.[1] (Table 1,2, and 3).
-    print(f"Lowest eigenvalue m={m}: {eps[0]}")
-    print(f"Binding energy    m={m}: {0.5 * B * (abs(m) + m + 1) - eps[0]}")
+    print(f"Lowest eigenvalue m={m}: {eps[0]:.3f}")
+    print(f"Binding energy    m={m}: {0.5 * B * (abs(m) + m + 1) - eps[0]:.3f}")
     print()

--- a/grid_lib/spherical_coordinates/angular_matrix_elements.py
+++ b/grid_lib/spherical_coordinates/angular_matrix_elements.py
@@ -8,26 +8,26 @@ import scipy.special
 from packaging import version
 
 
-def sph_harm_y(m, n, phi, theta):
+def sph_harm_y(m, l, phi, theta):
     """
     Args:
-        m: azimuthal quantum number
-        n: Degree of the harmonic, commonly denoted as l in quantum mechanics
+        m: magnetic quantum number
+        l: orbital angular momentum quantum number
         theta: polar angle in [0,pi]
         phi: azimuthal angle in [0, 2pi)
     --------------------------------------------------------------------------------------------------------
     --------------------------------------------------------------------------------------------------------
     In Scipy < 1.15.0
-    sph_harm: sph_harm(m, n, theta, phi, out=None)
-        - m: azimuthal quantum number
-        - n: Degree of the harmonic, commonly denoted as l in quantum mechanics
+    sph_harm: sph_harm(m, l, theta, phi, out=None)
+        - m: magnetic quantum number
+        - l: orbital angular momentum quantum number
         - theta in [0, 2pi): azimuthal angle
         - phi in [0,pi]: polar angle
 
     In SciPy >= 1.15.0 sph_harm is deprecated (and will be removed in SciPy 1.17.0) called sph_harm_y where
-    sph_harm_y: sph_harm_y(n, m, theta, phi, *, diff_n=0)
-        - m: azimuthal quantum number
-        - n: Degree of the harmonic, commonly denoted as l in quantum mechanics
+    sph_harm_y: sph_harm_y(l, m, theta, phi, *, diff_l=0)
+        - m: magnetic quantum number
+        - l: orbital angular momentum quantum number
         - theta in [0,pi]: polar angle
         - phi in [0, 2pi): azimuthal angle
     --------------------------------------------------------------------------------------------------------
@@ -37,10 +37,10 @@ def sph_harm_y(m, n, phi, theta):
 
     if scipy_version >= version.parse("1.15.0"):
         # New: sph_harm_y(degree, order, polar, azimuthal)
-        return scipy.special.sph_harm_y(n, m, theta, phi)
+        return scipy.special.sph_harm_y(l, m, theta, phi)
     else:
         # Old: sph_harm(order, degree, azimuthal, polar)
-        return scipy.special.sph_harm(m, n, phi, theta)
+        return scipy.special.sph_harm(m, l, phi, theta)
 
 
 class AngularMatrixElements:

--- a/grid_lib/spherical_coordinates/angular_matrix_elements.py
+++ b/grid_lib/spherical_coordinates/angular_matrix_elements.py
@@ -1,8 +1,46 @@
 import numpy as np
 import time
 from numpy.polynomial import legendre
-from scipy.special import eval_legendre as Legendre, sph_harm_y, spherical_jn
+from scipy.special import spherical_jn
 from pathlib import Path
+
+import scipy.special
+from packaging import version
+
+
+def sph_harm_y(m, n, phi, theta):
+    """
+    Args:
+        m: azimuthal quantum number
+        n: Degree of the harmonic, commonly denoted as l in quantum mechanics
+        theta: polar angle in [0,pi]
+        phi: azimuthal angle in [0, 2pi)
+    --------------------------------------------------------------------------------------------------------
+    --------------------------------------------------------------------------------------------------------
+    In Scipy < 1.15.0
+    sph_harm: sph_harm(m, n, theta, phi, out=None)
+        - m: azimuthal quantum number
+        - n: Degree of the harmonic, commonly denoted as l in quantum mechanics
+        - theta in [0, 2pi): azimuthal angle
+        - phi in [0,pi]: polar angle
+
+    In SciPy >= 1.15.0 sph_harm is deprecated (and will be removed in SciPy 1.17.0) called sph_harm_y where
+    sph_harm_y: sph_harm_y(n, m, theta, phi, *, diff_n=0)
+        - m: azimuthal quantum number
+        - n: Degree of the harmonic, commonly denoted as l in quantum mechanics
+        - theta in [0,pi]: polar angle
+        - phi in [0, 2pi): azimuthal angle
+    --------------------------------------------------------------------------------------------------------
+    --------------------------------------------------------------------------------------------------------
+    """
+    scipy_version = version.parse(scipy.__version__)
+
+    if scipy_version >= version.parse("1.15.0"):
+        # New: sph_harm_y(degree, order, polar, azimuthal)
+        return scipy.special.sph_harm_y(n, m, theta, phi)
+    else:
+        # Old: sph_harm(order, degree, azimuthal, polar)
+        return scipy.special.sph_harm(m, n, phi, theta)
 
 
 class AngularMatrixElements:
@@ -34,9 +72,7 @@ class AngularMatrixElements:
 
     def a_lm(self, l, m):
         if l >= 0 and abs(m) <= l:
-            return np.sqrt(
-                ((l + 1) ** 2 - m**2) / ((2 * l + 1) * (2 * l + 3))
-            )
+            return np.sqrt(((l + 1) ** 2 - m**2) / ((2 * l + 1) * (2 * l + 3)))
         else:
             return 0
 
@@ -530,19 +566,16 @@ class AngularMatrixElements_l(AngularMatrixElements):
                     and arr_to_calc_dict["z_Omega"] == False
                 ):
                     if abs(m) <= l1 and abs(m) <= l2:
-                        self.arr["H_z_beta"][
-                            l1, l2
-                        ] = -self.l1m1_sinth_ddtheta_l2m2(
-                            l1, m, l2, m
-                        ) - self.l1m1_costh_l2m2(
-                            l1, m, l2, m
+                        self.arr["H_z_beta"][l1, l2] = (
+                            -self.l1m1_sinth_ddtheta_l2m2(l1, m, l2, m)
+                            - self.l1m1_costh_l2m2(l1, m, l2, m)
                         )
                 if arr_to_calc_dict["H_Bz_Omega"]:
                     if abs(m) <= l1 and abs(m) <= l2:
-                        self.arr["H_Bz_Omega"][
-                            l1, l2
-                        ] = self.l1m1_sinth_sq_l2m2_Lebedev(
-                            Yl1m_cc, Yl2m, l1, m, l2, m
+                        self.arr["H_Bz_Omega"][l1, l2] = (
+                            self.l1m1_sinth_sq_l2m2_Lebedev(
+                                Yl1m_cc, Yl2m, l1, m, l2, m
+                            )
                         )
 
 
@@ -594,60 +627,60 @@ class AngularMatrixElements_lm(AngularMatrixElements):
                             Yl2m2 = sph_harm_y(m2, l2, self.phi, self.theta)
 
                             if arr_to_calc_dict["x_Omega"]:
-                                self.arr["x_Omega"][
-                                    I, J
-                                ] = self.l1m1_sinth_cosph_l2m2(l1, m1, l2, m2)
+                                self.arr["x_Omega"][I, J] = (
+                                    self.l1m1_sinth_cosph_l2m2(l1, m1, l2, m2)
+                                )
 
                             if arr_to_calc_dict["x_x_Omega"]:
-                                self.arr["x_x_Omega"][
-                                    I, J
-                                ] = self.l1m1_sinth_sq_cosph_sq_l2m2_Lebedev(
-                                    Yl1m1_cc, Yl2m2, l1, m1, l2, m2
+                                self.arr["x_x_Omega"][I, J] = (
+                                    self.l1m1_sinth_sq_cosph_sq_l2m2_Lebedev(
+                                        Yl1m1_cc, Yl2m2, l1, m1, l2, m2
+                                    )
                                 )
 
                             if arr_to_calc_dict["y_Omega"]:
-                                self.arr["y_Omega"][
-                                    I, J
-                                ] = self.l1m1_sinth_sinph_l2m2(l1, m1, l2, m2)
+                                self.arr["y_Omega"][I, J] = (
+                                    self.l1m1_sinth_sinph_l2m2(l1, m1, l2, m2)
+                                )
 
                             if arr_to_calc_dict["y_y_Omega"]:
-                                self.arr["y_y_Omega"][
-                                    I, J
-                                ] = self.l1m1_sinth_sq_sinph_sq_l2m2_Lebedev(
-                                    Yl1m1_cc, Yl2m2, l1, m1, l2, m2
+                                self.arr["y_y_Omega"][I, J] = (
+                                    self.l1m1_sinth_sq_sinph_sq_l2m2_Lebedev(
+                                        Yl1m1_cc, Yl2m2, l1, m1, l2, m2
+                                    )
                                 )
 
                             if arr_to_calc_dict["z_Omega"]:
-                                self.arr["z_Omega"][
-                                    I, J
-                                ] = self.l1m1_costh_l2m2(l1, m1, l2, m2)
+                                self.arr["z_Omega"][I, J] = (
+                                    self.l1m1_costh_l2m2(l1, m1, l2, m2)
+                                )
 
                             if arr_to_calc_dict["z_z_Omega"]:
-                                self.arr["z_z_Omega"][
-                                    I, J
-                                ] = self.l1m1_costh_sq_l2m2_Lebedev(
-                                    Yl1m1_cc, Yl2m2, l1, m1, l2, m2
+                                self.arr["z_z_Omega"][I, J] = (
+                                    self.l1m1_costh_sq_l2m2_Lebedev(
+                                        Yl1m1_cc, Yl2m2, l1, m1, l2, m2
+                                    )
                                 )
 
                             if arr_to_calc_dict["z_x_Omega"]:
-                                self.arr["z_x_Omega"][
-                                    I, J
-                                ] = self.l1m1_costh_sinth_cosph_l2m2_Lebedev(
-                                    Yl1m1_cc, Yl2m2, l1, m1, l2, m2
+                                self.arr["z_x_Omega"][I, J] = (
+                                    self.l1m1_costh_sinth_cosph_l2m2_Lebedev(
+                                        Yl1m1_cc, Yl2m2, l1, m1, l2, m2
+                                    )
                                 )
 
                             if arr_to_calc_dict["z_y_Omega"]:
-                                self.arr["z_y_Omega"][
-                                    I, J
-                                ] = self.l1m1_costh_sinth_sinph_l2m2_Lebedev(
-                                    Yl1m1_cc, Yl2m2, l1, m1, l2, m2
+                                self.arr["z_y_Omega"][I, J] = (
+                                    self.l1m1_costh_sinth_sinph_l2m2_Lebedev(
+                                        Yl1m1_cc, Yl2m2, l1, m1, l2, m2
+                                    )
                                 )
 
                             if arr_to_calc_dict["y_x_Omega"]:
-                                self.arr["y_x_Omega"][
-                                    I, J
-                                ] = self.l1m1_sinph_cosph_sinthsq_l2m2(
-                                    Yl1m1_cc, Yl2m2, l1, m1, l2, m2
+                                self.arr["y_x_Omega"][I, J] = (
+                                    self.l1m1_sinph_cosph_sinthsq_l2m2(
+                                        Yl1m1_cc, Yl2m2, l1, m1, l2, m2
+                                    )
                                 )
 
                             if arr_to_calc_dict["y_px_beta"]:
@@ -723,10 +756,10 @@ class AngularMatrixElements_lm(AngularMatrixElements):
                                 )
 
                             if arr_to_calc_dict["H_Bz_Omega"]:
-                                self.arr["H_Bz_Omega"][
-                                    I, J
-                                ] = self.l1m1_sinth_sq_l2m2_Lebedev(
-                                    Yl1m1_cc, Yl2m2, l1, m1, l2, m2
+                                self.arr["H_Bz_Omega"][I, J] = (
+                                    self.l1m1_sinth_sq_l2m2_Lebedev(
+                                        Yl1m1_cc, Yl2m2, l1, m1, l2, m2
+                                    )
                                 )
         toc = time.time()
         print(f"Time setup angular matrix elements: {toc-tic}")


### PR DESCRIPTION
SciPy 1.15.0 deprecated scipy.special.sph_harm in favor of scipy.special.sph_harm_y. The new function introduces breaking changes: it swaps the order of degree/order (n,m) and the order of coordinate angles (polar, azimuthal).

This pull request adds a compatibility wrapper to ensure the codebase remains functional across SciPy versions < 1.15 and >= 1.15.