### PR TITLE
Clamped molecular potentials in spherical coordinates

### DIFF
--- a/examples/clamped_molecular_potential_quadrature_vs_poisson.py
+++ b/examples/clamped_molecular_potential_quadrature_vs_poisson.py
@@ -1,0 +1,82 @@
+import numpy as np
+from matplotlib import pyplot as plt
+
+from grid_lib.pseudospectral_grids.femdvr import FEMDVR
+from grid_lib.pseudospectral_grids.gauss_legendre_lobatto import (
+    GaussLegendreLobatto,
+    Linear_map,
+)
+from grid_lib.spherical_coordinates.angular_momentum import LM_to_I
+from grid_lib.spherical_coordinates.potentials import (
+    clamped_molecular_potential_Poisson,
+    clamped_molecular_potential_quadrature,
+)
+from grid_lib.spherical_coordinates.radial_Coulomb import radial_Coulomb
+
+
+l_max = 1
+m_max = 0
+L_max = 2 * l_max
+M_max = 2 * m_max
+
+Z1 = 3
+Z2 = 1
+a1 = np.array([0.0, 0.0, -1.525])
+a2 = np.array([0.0, 0.0, 1.525])
+
+# Make r = 1.525 an explicit FEMDVR node.
+nodes = np.array([0.0, 1.525, 3.05, 6.10, 9.15, 12.20])
+n_points = np.array([25, 25, 25, 25, 25])
+
+femdvr = FEMDVR(nodes, n_points, Linear_map, GaussLegendreLobatto)
+r = femdvr.r[1:-1]
+weights = femdvr.weights[1:-1]
+W = radial_Coulomb(femdvr, L_max + 1)
+
+r_idx = np.argmin(np.abs(r - 1.525))
+assert np.isclose(r[r_idx], 1.525)
+a = r[r_idx]
+
+positions = np.array([a1, a2])
+charges = np.array([Z1, Z2])
+
+V_quad = clamped_molecular_potential_quadrature(
+    r,
+    positions=positions,
+    charges=charges,
+    L_max=L_max,
+    M_max=M_max,
+)
+V_poisson = clamped_molecular_potential_Poisson(
+    r,
+    W,
+    weights,
+    positions=positions,
+    charges=charges,
+    L_max=L_max,
+    M_max=M_max,
+)
+
+print(f"Grid point used for |a1| and |a2|: r[{r_idx}] = {r[r_idx]:.6f}")
+
+fig, axes = plt.subplots(L_max + 1, 1, sharex=True, figsize=(8, 8))
+
+for L in range(L_max + 1):
+    ax = axes[L]
+    I_L0 = LM_to_I(L, 0, L_max, M_max)
+
+    ax.plot(r, V_quad[I_L0].real, label='quadrature')
+    ax.plot(r, V_poisson[I_L0].real, '--', label='Poisson')
+    ax.axvline(a, color='k', linestyle=':', linewidth=1.0)
+    ax.set_ylabel(rf'$V_{{{L}0}}(r)$')
+    ax.grid(True)
+
+axes[0].legend()
+axes[-1].set_xlabel(r'$r$')
+fig.suptitle(
+    'Clamped diatomic potential on the z-axis\n'
+    r'$Z_1 = 3$, $Z_2 = 1$, $a_1 = (0,0,-1.525)$, '
+    r'$a_2 = (0,0,1.525)$'
+)
+fig.tight_layout()
+plt.show()

--- a/grid_lib/__init__.py
+++ b/grid_lib/__init__.py
@@ -3,4 +3,5 @@ from .spherical_coordinates import (
     Coulomb,
     SAE,
     Gaussian_charge_distribution,
+    clamped_molecular_potential_quadrature,
 )

--- a/grid_lib/__init__.py
+++ b/grid_lib/__init__.py
@@ -3,5 +3,6 @@ from .spherical_coordinates import (
     Coulomb,
     SAE,
     Gaussian_charge_distribution,
+    clamped_molecular_potential_Poisson,
     clamped_molecular_potential_quadrature,
 )

--- a/grid_lib/spherical_coordinates/__init__.py
+++ b/grid_lib/spherical_coordinates/__init__.py
@@ -2,6 +2,7 @@ from .potentials import (
     Coulomb,
     SAE,
     Gaussian_charge_distribution,
+    clamped_molecular_potential_Poisson,
     clamped_molecular_potential_quadrature,
 )
 from .propagators import Propagator, BiCGstab

--- a/grid_lib/spherical_coordinates/__init__.py
+++ b/grid_lib/spherical_coordinates/__init__.py
@@ -1,2 +1,7 @@
-from .potentials import Coulomb, SAE, Gaussian_charge_distribution
+from .potentials import (
+    Coulomb,
+    SAE,
+    Gaussian_charge_distribution,
+    clamped_molecular_potential_quadrature,
+)
 from .propagators import Propagator, BiCGstab

--- a/grid_lib/spherical_coordinates/angular_matrix_elements.py
+++ b/grid_lib/spherical_coordinates/angular_matrix_elements.py
@@ -3,44 +3,7 @@ import time
 from numpy.polynomial import legendre
 from scipy.special import spherical_jn
 from pathlib import Path
-
-import scipy.special
-from packaging import version
-
-
-def sph_harm_y(m, l, phi, theta):
-    """
-    Args:
-        m: magnetic quantum number
-        l: orbital angular momentum quantum number
-        theta: polar angle in [0,pi]
-        phi: azimuthal angle in [0, 2pi)
-    --------------------------------------------------------------------------------------------------------
-    --------------------------------------------------------------------------------------------------------
-    In Scipy < 1.15.0
-    sph_harm: sph_harm(m, l, theta, phi, out=None)
-        - m: magnetic quantum number
-        - l: orbital angular momentum quantum number
-        - theta in [0, 2pi): azimuthal angle
-        - phi in [0,pi]: polar angle
-
-    In SciPy >= 1.15.0 sph_harm is deprecated (and will be removed in SciPy 1.17.0) called sph_harm_y where
-    sph_harm_y: sph_harm_y(l, m, theta, phi, *, diff_l=0)
-        - m: magnetic quantum number
-        - l: orbital angular momentum quantum number
-        - theta in [0,pi]: polar angle
-        - phi in [0, 2pi): azimuthal angle
-    --------------------------------------------------------------------------------------------------------
-    --------------------------------------------------------------------------------------------------------
-    """
-    scipy_version = version.parse(scipy.__version__)
-
-    if scipy_version >= version.parse("1.15.0"):
-        # New: sph_harm_y(degree, order, polar, azimuthal)
-        return scipy.special.sph_harm_y(l, m, theta, phi)
-    else:
-        # Old: sph_harm(order, degree, azimuthal, polar)
-        return scipy.special.sph_harm(m, l, phi, theta)
+from .utils import sph_harm_y
 
 
 class AngularMatrixElements:

--- a/grid_lib/spherical_coordinates/angular_momentum.py
+++ b/grid_lib/spherical_coordinates/angular_momentum.py
@@ -1,22 +1,4 @@
 import numpy as np
-
-from scipy.special import sph_harm, lpmv as Pml, factorial
-
-"""
-In Scipy 1.10.1 
-sph_harm: sph_harm(m, n, theta, phi, out=None)
-    - m: azimuthal quantum number
-    - n: Degree of the harmonic, commonly denoted as l in quantum mechanics
-    - theta in [0, 2pi): azimuthal angle 
-    - phi in [0,pi]: polar angle
-
-In SciPy 1.15.2 sph_harm is deprecated (and will be removed in SciPy 1.17.0) called sph_harm_y where 
-sph_harm_y: sph_harm_y(n, m, theta, phi, *, diff_n=0)
-    - m: azimuthal quantum number
-    - n: Degree of the harmonic, commonly denoted as l in quantum mechanics
-    - theta in [0,pi]: polar angle
-    - phi in [0, 2pi): azimuthal angle
-"""
 from sympy.physics.wigner import gaunt
 from numba import njit
 

--- a/grid_lib/spherical_coordinates/potentials.py
+++ b/grid_lib/spherical_coordinates/potentials.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 from scipy.special import erf
 
@@ -185,6 +187,103 @@ def clamped_molecular_potential_quadrature(
                     * angular_factor
                     * radial_factor
                 )
+
+    if np.allclose(V_LM.imag, 0.0):
+        return V_LM.real
+
+    return V_LM
+
+
+def clamped_molecular_potential_Poisson(
+    r, W, weights, positions, charges, L_max, M_max=None
+):
+    r"""
+    Compute the spherical-harmonic radial coefficients of a clamped
+    molecular point-charge potential from a Poisson-solved radial kernel.
+
+    The input ``W`` is assumed to contain the radial Coulomb components
+    already including the factor ``4\pi / (2L + 1)``. For each nucleus,
+    the nearest radial grid point is used in the source coordinate and the
+    corresponding column is divided by the quadrature weight at that point.
+
+    Parameters
+    ----------
+    r : array_like
+        Radial grid values corresponding to the source coordinate of ``W``.
+    W : array_like
+        Array of shape ``(n_L, len(r), len(r))`` containing the radial
+        Coulomb kernel.
+    weights : array_like
+        Quadrature weights corresponding to ``r``.
+    positions : array_like
+        Cartesian nuclear positions with shape ``(n_nuclei, 3)``.
+    charges : array_like
+        Nuclear charges with shape ``(n_nuclei,)``.
+    L_max : int
+        Maximum multipole rank in the expansion.
+    M_max : int, optional
+        Maximum magnetic quantum number stored. Defaults to ``L_max``.
+
+    Returns
+    -------
+    np.ndarray
+        Array of shape ``(n_LM, len(r))`` storing ``V_{LM}(r)`` in the
+        repo's ``LM_to_I`` ordering.
+    """
+    r = np.asarray(r, dtype=float)
+    W = np.asarray(W)
+    weights = np.asarray(weights, dtype=float)
+    positions = np.asarray(positions, dtype=float)
+    charges = np.asarray(charges, dtype=float)
+
+    if L_max < 0:
+        raise ValueError("L_max must be >= 0")
+
+    if M_max is None:
+        M_max = L_max
+    if M_max < 0 or M_max > L_max:
+        raise ValueError("Require 0 <= M_max <= L_max")
+
+    if r.ndim != 1:
+        raise ValueError("r must be a one-dimensional array")
+    if W.ndim != 3:
+        raise ValueError("W must have shape (n_L, len(r), len(r))")
+    if W.shape[1:] != (len(r), len(r)):
+        raise ValueError("W must have shape (n_L, len(r), len(r))")
+    if weights.ndim != 1 or len(weights) != len(r):
+        raise ValueError("weights must be a one-dimensional array of len(r)")
+    if positions.ndim != 2 or positions.shape[1] != 3:
+        raise ValueError("positions must have shape (n_nuclei, 3)")
+    if charges.ndim != 1:
+        raise ValueError("charges must be a one-dimensional array")
+    if len(positions) != len(charges):
+        raise ValueError("positions and charges must have the same length")
+    if W.shape[0] < L_max + 1:
+        raise ValueError("W must contain at least L_max + 1 angular ranks")
+
+    n_LM = number_of_lm_states(L_max, M_max)
+    V_LM = np.zeros((n_LM, len(r)), dtype=complex)
+
+    for position, charge in zip(positions, charges):
+        R, theta_R, phi_R = cartesian_to_spherical(position)
+        r_idx = np.argmin(np.abs(r - R))
+
+        if not np.isclose(r[r_idx], R):
+            warnings.warn(
+                (
+                    "Nuclear radius %.16g is not a grid point; "
+                    "using nearest grid point %.16g."
+                )
+                % (R, r[r_idx]),
+                stacklevel=2,
+            )
+
+        for M in range(-M_max, M_max + 1):
+            for L in range(abs(M), L_max + 1):
+                I_LM = LM_to_I(L, M, L_max, M_max)
+                angular_factor = Ylm(L, M, theta_R, phi_R)
+                radial_factor = W[L, :, r_idx] / weights[r_idx]
+                V_LM[I_LM] += -charge * angular_factor * radial_factor
 
     if np.allclose(V_LM.imag, 0.0):
         return V_LM.real

--- a/grid_lib/spherical_coordinates/potentials.py
+++ b/grid_lib/spherical_coordinates/potentials.py
@@ -1,6 +1,9 @@
 import numpy as np
 from scipy.special import erf
 
+from .angular_momentum import LM_to_I, number_of_lm_states
+from .utils import Ylm, cartesian_to_spherical
+
 
 class Coulomb:
     def __init__(self, Z):
@@ -96,3 +99,94 @@ class Erfgau:
         return -self.Z**2 * (
             c * np.exp(-(alpha**2) * self.Z**2 * r**2) + long_range
         )
+
+
+def clamped_molecular_potential_quadrature(
+    r, positions, charges, L_max, M_max=None
+):
+    r"""
+    Compute the spherical-harmonic radial coefficients of a clamped
+    molecular point-charge potential from the analytic multipole kernel.
+
+    The potential is expanded as
+
+    .. math::
+        V(\mathbf{r}) = \sum_{L,M} V_{LM}(r) Y_{LM}(\Omega),
+
+    where for point charges located at ``R_A``,
+
+    .. math::
+        V_{LM}(r) = -\sum_A Z_A \frac{4\pi}{2L+1}
+        \frac{r_<^L}{r_>^{L+1}} Y_{LM}^*(\Omega_A).
+
+    Parameters
+    ----------
+    r : array_like
+        Radial grid values where the coefficients are evaluated.
+    positions : array_like
+        Cartesian nuclear positions with shape ``(n_nuclei, 3)``.
+    charges : array_like
+        Nuclear charges with shape ``(n_nuclei,)``.
+    L_max : int
+        Maximum multipole rank in the expansion.
+    M_max : int, optional
+        Maximum magnetic quantum number stored. Defaults to ``L_max``.
+
+    Returns
+    -------
+    np.ndarray
+        Array of shape ``(n_LM, len(r))`` storing ``V_{LM}(r)`` in the
+        repo's ``LM_to_I`` ordering.
+    """
+    r = np.asarray(r, dtype=float)
+    positions = np.asarray(positions, dtype=float)
+    charges = np.asarray(charges, dtype=float)
+
+    if L_max < 0:
+        raise ValueError("L_max must be >= 0")
+
+    if M_max is None:
+        M_max = L_max
+    if M_max < 0 or M_max > L_max:
+        raise ValueError("Require 0 <= M_max <= L_max")
+
+    if r.ndim != 1:
+        raise ValueError("r must be a one-dimensional array")
+    if positions.ndim != 2 or positions.shape[1] != 3:
+        raise ValueError("positions must have shape (n_nuclei, 3)")
+    if charges.ndim != 1:
+        raise ValueError("charges must be a one-dimensional array")
+    if len(positions) != len(charges):
+        raise ValueError("positions and charges must have the same length")
+
+    n_LM = number_of_lm_states(L_max, M_max)
+    V_LM = np.zeros((n_LM, len(r)), dtype=complex)
+
+    for position, charge in zip(positions, charges):
+        R = np.linalg.norm(position)
+
+        if R == 0:
+            I_00 = LM_to_I(0, 0, L_max, M_max)
+            V_LM[I_00] += -charge * np.sqrt(4 * np.pi) / r
+            continue
+
+        _, theta_R, phi_R = cartesian_to_spherical(position)
+        r_min = np.minimum(r, R)
+        r_max = np.maximum(r, R)
+
+        for M in range(-M_max, M_max + 1):
+            for L in range(abs(M), L_max + 1):
+                I_LM = LM_to_I(L, M, L_max, M_max)
+                angular_factor = Ylm(L, M, theta_R, phi_R)
+                radial_factor = (r_min**L) / (r_max ** (L + 1))
+                V_LM[I_LM] += (
+                    -charge
+                    * (4 * np.pi / (2 * L + 1))
+                    * angular_factor
+                    * radial_factor
+                )
+
+    if np.allclose(V_LM.imag, 0.0):
+        return V_LM.real
+
+    return V_LM

--- a/grid_lib/spherical_coordinates/utils.py
+++ b/grid_lib/spherical_coordinates/utils.py
@@ -88,3 +88,36 @@ def Ylm(l, m, theta, phi):
     theta = np.asarray(theta)
     phi = np.asarray(phi)
     return sph_harm_y(m, l, phi, theta)
+
+
+def cartesian_to_spherical(a):
+    """
+    Convert a 3D Cartesian point to spherical coordinates.
+
+    Parameters
+    ----------
+    a : array_like
+        Cartesian point ``(a1, a2, a3)``.
+
+    Returns
+    -------
+    r : float
+        Radius.
+    theta : float
+        Polar angle in ``[0, pi]``.
+    phi : float
+        Azimuthal angle in ``[0, 2*pi)``. At the poles, ``phi = 0`` is
+        returned by convention.
+    """
+    a = np.asarray(a, dtype=float)
+    if a.shape != (3,):
+        raise ValueError('Expected a 3D vector with shape (3,)')
+
+    r = np.linalg.norm(a)
+    if r == 0:
+        raise ValueError('Spherical angles are undefined for the zero vector')
+
+    theta = np.arccos(a[2] / r)
+    phi = np.mod(np.arctan2(a[1], a[0]), 2 * np.pi)
+
+    return r, theta, phi

--- a/grid_lib/spherical_coordinates/utils.py
+++ b/grid_lib/spherical_coordinates/utils.py
@@ -1,5 +1,7 @@
 import numpy as np
 from opt_einsum import contract
+import scipy.special
+from packaging import version
 
 
 def lowdin_orthogonalize(A, weights):
@@ -48,3 +50,41 @@ def mask_function(r, r_max, r0, n=4):
     )
 
     return mask_r
+
+
+def sph_harm_y(m, l, phi, theta):
+    """
+    Compute Y_{l,m}(theta, phi) with a stable angle convention across SciPy versions.
+
+    Args:
+        m: magnetic quantum number
+        l: orbital angular momentum quantum number
+        phi: azimuthal angle in [0, 2*pi)
+        theta: polar angle in [0, pi]
+    """
+    scipy_version = version.parse(scipy.__version__)
+
+    if scipy_version >= version.parse("1.15.0"):
+        return scipy.special.sph_harm_y(l, m, theta, phi)
+
+    return scipy.special.sph_harm(m, l, phi, theta)
+
+
+def Ylm(l, m, theta, phi):
+    """
+    Compute the complex spherical harmonic Y_{l,m}(theta, phi).
+
+    Args:
+        l: orbital angular momentum quantum number
+        m: magnetic quantum number
+        theta: polar angle in [0, pi]
+        phi: azimuthal angle in [0, 2*pi)
+    """
+    if l < 0:
+        raise ValueError("l must be >= 0")
+    if abs(m) > l:
+        raise ValueError("Require |m| <= l")
+
+    theta = np.asarray(theta)
+    phi = np.asarray(phi)
+    return sph_harm_y(m, l, phi, theta)

--- a/tests/test_spherical_coordinate_utils.py
+++ b/tests/test_spherical_coordinate_utils.py
@@ -1,0 +1,27 @@
+import numpy as np
+
+from grid_lib.spherical_coordinates.utils import cartesian_to_spherical
+
+
+def test_cartesian_to_spherical_on_axes():
+    test_cases = [
+        ((1, 0, 0), (1.0, np.pi / 2, 0.0)),
+        ((-1, 0, 0), (1.0, np.pi / 2, np.pi)),
+        ((0, 1, 0), (1.0, np.pi / 2, np.pi / 2)),
+        ((0, -1, 0), (1.0, np.pi / 2, 3 * np.pi / 2)),
+        ((0, 0, 1), (1.0, 0.0, 0.0)),
+        ((0, 0, -1), (1.0, np.pi, 0.0)),
+    ]
+
+    for point, expected in test_cases:
+        computed = cartesian_to_spherical(point)
+        np.testing.assert_allclose(computed, expected, rtol=0.0, atol=1e-15)
+
+
+def test_cartesian_to_spherical_off_axis():
+    point = (0, 1, 1)
+    expected = (np.sqrt(2), np.pi / 4, np.pi / 2)
+
+    computed = cartesian_to_spherical(point)
+
+    np.testing.assert_allclose(computed, expected, rtol=0.0, atol=1e-15)

--- a/tests/test_spherical_potentials.py
+++ b/tests/test_spherical_potentials.py
@@ -1,0 +1,56 @@
+import numpy as np
+
+from grid_lib.spherical_coordinates.angular_momentum import LM_to_I
+from grid_lib.spherical_coordinates.potentials import (
+    clamped_molecular_potential_quadrature,
+)
+
+
+def test_clamped_molecular_potential_quadrature_for_centered_nucleus():
+    r = np.array([0.5, 1.0, 2.0])
+    V_LM = clamped_molecular_potential_quadrature(
+        r,
+        positions=[[0.0, 0.0, 0.0]],
+        charges=[2.0],
+        L_max=3,
+        M_max=2,
+    )
+
+    I_00 = LM_to_I(0, 0, 3, 2)
+    np.testing.assert_allclose(V_LM[I_00], -2.0 * np.sqrt(4 * np.pi) / r)
+
+    mask = np.ones(V_LM.shape[0], dtype=bool)
+    mask[I_00] = False
+    np.testing.assert_allclose(V_LM[mask], 0.0, atol=1e-14, rtol=0.0)
+
+
+def test_clamped_molecular_potential_quadrature_for_displaced_nucleus_on_z_axis():
+    r = np.array([0.5, 1.0, 2.0, 4.0])
+    a = 1.5
+    L_max = 4
+    M_max = 3
+
+    V_LM = clamped_molecular_potential_quadrature(
+        r,
+        positions=[[0.0, 0.0, a]],
+        charges=[1.0],
+        L_max=L_max,
+        M_max=M_max,
+    )
+
+    r_min = np.minimum(r, a)
+    r_max = np.maximum(r, a)
+
+    for M in range(-M_max, M_max + 1):
+        for L in range(abs(M), L_max + 1):
+            I_LM = LM_to_I(L, M, L_max, M_max)
+
+            if M == 0:
+                expected = -np.sqrt(4 * np.pi / (2 * L + 1)) * (
+                    r_min**L / r_max ** (L + 1)
+                )
+                np.testing.assert_allclose(V_LM[I_LM], expected)
+            else:
+                np.testing.assert_allclose(
+                    V_LM[I_LM], 0.0, atol=1e-14, rtol=0.0
+                )

--- a/tests/test_spherical_potentials.py
+++ b/tests/test_spherical_potentials.py
@@ -1,8 +1,17 @@
 import numpy as np
+import pytest
 
 from grid_lib.spherical_coordinates.angular_momentum import LM_to_I
 from grid_lib.spherical_coordinates.potentials import (
+    clamped_molecular_potential_Poisson,
     clamped_molecular_potential_quadrature,
+)
+from grid_lib.spherical_coordinates.radial_Coulomb import radial_Coulomb
+from grid_lib.spherical_coordinates.utils import Ylm, cartesian_to_spherical
+from grid_lib.pseudospectral_grids.femdvr import FEMDVR
+from grid_lib.pseudospectral_grids.gauss_legendre_lobatto import (
+    GaussLegendreLobatto,
+    Linear_map,
 )
 
 
@@ -54,3 +63,80 @@ def test_clamped_molecular_potential_quadrature_for_displaced_nucleus_on_z_axis(
                 np.testing.assert_allclose(
                     V_LM[I_LM], 0.0, atol=1e-14, rtol=0.0
                 )
+
+
+def test_clamped_molecular_potential_poisson_assembles_components_from_W():
+    nodes = np.arange(0.0, 6.0 + 1.0, 1.0)
+    n_points = np.ones((len(nodes) - 1,), dtype=int) * 6
+    femdvr = FEMDVR(nodes, n_points, Linear_map, GaussLegendreLobatto)
+
+    r = femdvr.r[1:-1]
+    weights = femdvr.weights[1:-1]
+    L_max = 4
+    M_max = 3
+    W = radial_Coulomb(femdvr, L_max + 1)
+
+    r_idx = len(r) // 3
+    a = r[r_idx]
+    position = np.array([a / np.sqrt(3), a / np.sqrt(3), a / np.sqrt(3)])
+    V_poisson = clamped_molecular_potential_Poisson(
+        r,
+        W,
+        weights,
+        positions=[position],
+        charges=[1.0],
+        L_max=L_max,
+        M_max=M_max,
+    )
+
+    _, theta, phi = cartesian_to_spherical(position)
+    V_expected = np.zeros_like(V_poisson, dtype=complex)
+
+    for M in range(-M_max, M_max + 1):
+        for L in range(abs(M), L_max + 1):
+            I_LM = LM_to_I(L, M, L_max, M_max)
+            V_expected[I_LM] = -Ylm(L, M, theta, phi) * W[L, :, r_idx] / weights[r_idx]
+
+    np.testing.assert_allclose(V_poisson, V_expected, atol=1e-14, rtol=1e-14)
+
+
+def test_clamped_molecular_potential_poisson_warns_and_uses_nearest_grid_point():
+    nodes = np.arange(0.0, 6.0 + 1.0, 1.0)
+    n_points = np.ones((len(nodes) - 1,), dtype=int) * 6
+    femdvr = FEMDVR(nodes, n_points, Linear_map, GaussLegendreLobatto)
+
+    r = femdvr.r[1:-1]
+    weights = femdvr.weights[1:-1]
+    L_max = 4
+    M_max = 3
+    W = radial_Coulomb(femdvr, L_max + 1)
+
+    a = 1.23
+    position = np.array([0.0, 0.0, a])
+    nearest_idx = np.argmin(np.abs(r - a))
+    snapped_position = np.array([0.0, 0.0, r[nearest_idx]])
+
+    with pytest.warns(
+        UserWarning, match="not a grid point; using nearest grid point"
+    ):
+        V_poisson = clamped_molecular_potential_Poisson(
+            r,
+            W,
+            weights,
+            positions=[position],
+            charges=[1.0],
+            L_max=L_max,
+            M_max=M_max,
+        )
+
+    V_expected = clamped_molecular_potential_Poisson(
+        r,
+        W,
+        weights,
+        positions=[snapped_position],
+        charges=[1.0],
+        L_max=L_max,
+        M_max=M_max,
+    )
+
+    np.testing.assert_allclose(V_poisson, V_expected, atol=1e-14, rtol=1e-14)


### PR DESCRIPTION
**Summary**
This pull request adds support for constructing clamped molecular potentials in spherical coordinates using both an analytic quadrature-based multipole expansion and a Poisson-based radial construction. It also includes the supporting spherical-coordinate utilities introduced yesterday, along with tests and an example comparing the two constructions for a diatomic potential on the `z` axis.

**Implementation**
- Add shared spherical-harmonic utilities in `grid_lib.spherical_coordinates.utils`.
- Add `cartesian_to_spherical` for converting Cartesian nuclear positions to spherical coordinates.
- Add `clamped_molecular_potential_quadrature` to compute `V_LM(r)` from the analytic kernel `r_<^L / r_>^(L+1)` for general 3D nuclear positions.
- Add `clamped_molecular_potential_Poisson` to compute `V_LM(r)` from a precomputed Poisson-based radial Coulomb tensor `W`.
- In the Poisson-based helper, use the nearest radial grid point when a nuclear radius is off-grid and issue a warning in that case.
- Export the new helpers from `grid_lib.spherical_coordinates` and top-level `grid_lib`.
- Remove redundant imports/comments in the spherical angular-momentum module.

**Testing**
- Add tests for `cartesian_to_spherical`.
- Add tests for `clamped_molecular_potential_quadrature` for centered and displaced nuclei.
- Add tests for `clamped_molecular_potential_Poisson` covering assembly from `W` and warning/nearest-grid behavior.
- Verify the new example script compiles and runs.

**Example**
- Add `examples/clamped_molecular_potential_quadrature_vs_poisson.py`, which compares quadrature and Poisson radial components for a diatomic potential on the `z` axis using a FEMDVR grid.
