### PR TITLE
Molecular potential sphc

### DIFF
--- a/grid_lib/spherical_coordinates/potentials.py
+++ b/grid_lib/spherical_coordinates/potentials.py
@@ -265,7 +265,14 @@ def clamped_molecular_potential_Poisson(
     V_LM = np.zeros((n_LM, len(r)), dtype=complex)
 
     for position, charge in zip(positions, charges):
-        R, theta_R, phi_R = cartesian_to_spherical(position)
+        R = np.linalg.norm(position)
+
+        if R == 0:
+            I_00 = LM_to_I(0, 0, L_max, M_max)
+            V_LM[I_00] += -charge * np.sqrt(4 * np.pi) / r
+            continue
+
+        _, theta_R, phi_R = cartesian_to_spherical(position)
         r_idx = np.argmin(np.abs(r - R))
 
         if not np.isclose(r[r_idx], R):


### PR DESCRIPTION
**Handle zero-position nucleus in `clamped_molecular_potential_Poisson`**

Previously, passing a nucleus at the origin would raise a `ValueError` from `cartesian_to_spherical`, since spherical angles are undefined for the zero vector. This change adds an explicit check: if a nuclear position is the zero vector, the analytic Coulomb potential $-Z/r$ is added directly to the $L=0, M=0$ coefficient (as $-Z\sqrt{4\pi}/r$), consistent with the behaviour of `clamped_molecular_potential_quadrature`.