### PR TITLE
Raise ValueError for off-grid nucleus in clamped_molecular_potential_Poisson

### DIFF
--- a/grid_lib/spherical_coordinates/potentials.py
+++ b/grid_lib/spherical_coordinates/potentials.py
@@ -195,7 +195,7 @@ def clamped_molecular_potential_quadrature(
 
 
 def clamped_molecular_potential_Poisson(
-    r, W, weights, positions, charges, L_max, M_max=None
+    r, W, weights, positions, charges, L_max, M_max=None, force=False
 ):
     r"""
     Compute the spherical-harmonic radial coefficients of a clamped
@@ -223,6 +223,10 @@ def clamped_molecular_potential_Poisson(
         Maximum multipole rank in the expansion.
     M_max : int, optional
         Maximum magnetic quantum number stored. Defaults to ``L_max``.
+    force : bool, optional
+        If ``True``, issue a warning and use the nearest grid point when a
+        nuclear radius does not coincide with a grid point. If ``False``
+        (default), raise a ``ValueError`` instead.
 
     Returns
     -------
@@ -276,14 +280,15 @@ def clamped_molecular_potential_Poisson(
         r_idx = np.argmin(np.abs(r - R))
 
         if not np.isclose(r[r_idx], R):
-            warnings.warn(
-                (
-                    "Nuclear radius %.16g is not a grid point; "
-                    "using nearest grid point %.16g."
+            msg = (
+                "Nuclear radius %.16g is not a grid point; "
+                "nearest grid point is %.16g."
+            ) % (R, r[r_idx])
+            if not force:
+                raise ValueError(
+                    msg + " Pass force=True to use the nearest grid point."
                 )
-                % (R, r[r_idx]),
-                stacklevel=2,
-            )
+            warnings.warn(msg + " Using nearest grid point.", stacklevel=2)
 
         for M in range(-M_max, M_max + 1):
             for L in range(abs(M), L_max + 1):

--- a/tests/test_spherical_potentials.py
+++ b/tests/test_spherical_potentials.py
@@ -117,7 +117,7 @@ def test_clamped_molecular_potential_poisson_warns_and_uses_nearest_grid_point()
     snapped_position = np.array([0.0, 0.0, r[nearest_idx]])
 
     with pytest.warns(
-        UserWarning, match="not a grid point; using nearest grid point"
+        UserWarning, match="not a grid point; nearest grid point"
     ):
         V_poisson = clamped_molecular_potential_Poisson(
             r,
@@ -127,6 +127,7 @@ def test_clamped_molecular_potential_poisson_warns_and_uses_nearest_grid_point()
             charges=[1.0],
             L_max=L_max,
             M_max=M_max,
+            force=True,
         )
 
     V_expected = clamped_molecular_potential_Poisson(


### PR DESCRIPTION
**Raise error for off-grid nucleus in `clamped_molecular_potential_Poisson`; add `force` parameter**

Previously, if a nuclear radius did not coincide with a radial grid point, the function silently issued a warning and proceeded with the nearest grid point. This is potentially dangerous: the user may not notice the warning, and the result will be inaccurate without any indication of how large the error is.

**Changes**

- By default (`force=False`), a `ValueError` is now raised when a nuclear radius is not a grid point, halting execution and prompting the user to either adjust their grid or explicitly opt in to the approximation.
- Passing `force=True` restores the previous behaviour: a `UserWarning` is issued and the nearest grid point is used.
- The existing test for the off-grid warning case was updated to pass `force=True` and match the new warning message.

**Migration**

Code that previously relied on the silent fallback should add `force=True` to the call, or ideally adjust the radial grid so that nuclear positions coincide with grid points.