### PR TITLE
Improve pseudospectral_grids import convenience with package-level re-exports

### DIFF
--- a/grid_lib/pseudospectral_grids/__init__.py
+++ b/grid_lib/pseudospectral_grids/__init__.py
@@ -1,0 +1,5 @@
+from .femdvr import FEMDVR
+from .sinc_dvr import SincDVR
+from .gauss_legendre_lobatto import GaussLegendreLobatto
+
+__all__ = ["FEMDVR", "SincDVR", "GaussLegendreLobatto"]

--- a/grid_lib/pseudospectral_grids/__init__.py
+++ b/grid_lib/pseudospectral_grids/__init__.py
@@ -1,5 +1,5 @@
 from .femdvr import FEMDVR
 from .sinc_dvr import SincDVR
-from .gauss_legendre_lobatto import GaussLegendreLobatto
+from .gauss_legendre_lobatto import GaussLegendreLobatto, Linear_map
 
-__all__ = ["FEMDVR", "SincDVR", "GaussLegendreLobatto"]
+__all__ = ["FEMDVR", "SincDVR", "GaussLegendreLobatto", "Linear_map"]


### PR DESCRIPTION
## Summary
This PR improves import ergonomics for pseudospectral grid classes and mapping utilities by re-exporting commonly used symbols at the package level.

## What changed
- Added package-level re-exports in __init__.py:
  - FEMDVR
  - SincDVR
  - GaussLegendreLobatto
  - Linear_map
- Added and updated __all__ in __init__.py so these names are part of the intended public API.

## Why
These changes enable cleaner imports from a single package entry point instead of requiring module-specific paths. This makes usage simpler and more discoverable.

## User-facing impact
You can now import directly from the package:
from grid_lib.pseudospectral_grids import FEMDVR, SincDVR, GaussLegendreLobatto, Linear_map