### PR TITLE
Add pseudospectral grid setup utilities and integration/plotting example

### DIFF
--- a/examples/setup_different_grids.py
+++ b/examples/setup_different_grids.py
@@ -1,0 +1,99 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+from grid_lib.pseudospectral_grids import setup_femdvr_uniform, setup_grid
+
+
+def get_grid_points(grid):
+    if hasattr(grid, "x"):
+        return np.asarray(grid.x)
+    if hasattr(grid, "r"):
+        return np.asarray(grid.r)
+    raise AttributeError("Grid object has neither 'x' nor 'r' coordinates.")
+
+
+def get_grid_weights(grid):
+    for attr in ("weights", "w", "weight"):
+        if hasattr(grid, attr):
+            return np.asarray(getattr(grid, attr))
+    raise AttributeError("Grid object has no recognized quadrature weights attribute.")
+
+
+if __name__ == "__main__":
+    
+    # 1) Sinc DVR grid
+    sinc = setup_grid(
+        "sinc",
+        {
+            "x0": -8.0,
+            "xN": 8.0,
+            "N": 41,
+        },
+    )
+    
+    # 2) Gauss-Legendre-Lobatto grid using endpoint-based setup
+    gll = setup_grid(
+        "gll",
+        {
+            "N": 40,
+            "x0": -8.0,
+            "xN":  8.0,
+            "symmetrize": False,
+        },
+    )
+    
+    # 3) FEM-DVR grid with custom element boundaries and point counts
+    nodes = np.array([-8.0, -3.0, 0.0, 4.0, 8.0])
+    n_points = np.array([8, 10, 12, 10])
+    femdvr = setup_grid(
+        "femdvr",
+        {
+            "nodes": nodes,
+            "n_points": n_points,
+            "symmetrize": False,
+        },
+    )
+    
+    # 4) Convenience helper for a uniform FEM-DVR grid
+    femdvr_uniform = setup_femdvr_uniform(
+        x_min=-8.0,
+        x_max=8.0,
+        n_elements=4,
+        points_per_element=15,
+        symmetrize=False,
+    )
+    
+    grids = [
+        ("Sinc DVR", sinc, np.asarray(sinc.x)),
+        ("Gauss-Legendre-Lobatto", gll, np.asarray(gll.r)),
+        ("FEM-DVR", femdvr, np.asarray(femdvr.r)),
+        ("Uniform FEM-DVR", femdvr_uniform, np.asarray(femdvr_uniform.r)),
+    ]
+
+    print(f"Quadrature int exp(-x^2) dx = sqrt(pi) = {np.sqrt(np.pi):.8f}, x=-oo to x=oo")
+    for label, grid, x in grids:
+        w = get_grid_weights(grid)
+        f = np.exp(-(x**2))
+        integral_num = np.sum(w * f)
+        integral_exact = np.sqrt(np.pi)
+        abs_error = abs(integral_num - integral_exact)
+        print(
+            f"  {label}: I_num={integral_num:.8f}, "
+            f"|err|={abs_error:.2g}"
+        )
+
+    fig, axes = plt.subplots(2, 2, figsize=(12, 8), constrained_layout=True)
+    axes = axes.ravel()
+
+    for ax, (label, _, x) in zip(axes, grids):
+        y = np.exp(-(x**2))
+        ax.plot(x, y, "o-", lw=1.5, label="$e^{-x^2}$")
+        ax.set_title(label)
+        ax.set_xlabel("x")
+        ax.set_ylabel("f(x)")
+        ax.grid(True, alpha=0.3)
+        ax.legend(loc="best")
+
+    fig.suptitle("Function $f(x)=e^{-x^2}$ Sampled on Different Grids")
+    plt.show()

--- a/grid_lib/pseudospectral_grids/__init__.py
+++ b/grid_lib/pseudospectral_grids/__init__.py
@@ -1,5 +1,14 @@
 from .femdvr import FEMDVR
 from .sinc_dvr import SincDVR
-from .gauss_legendre_lobatto import GaussLegendreLobatto, Linear_map
+from .gauss_legendre_lobatto import GaussLegendreLobatto, Linear_map, Rational_map
+from .setup_grids import setup_grid, setup_femdvr_uniform
 
-__all__ = ["FEMDVR", "SincDVR", "GaussLegendreLobatto", "Linear_map"]
+__all__ = [
+	"FEMDVR",
+	"SincDVR",
+	"GaussLegendreLobatto",
+	"Linear_map",
+	"Rational_map",
+	"setup_grid",
+	"setup_femdvr_uniform",
+]

--- a/grid_lib/pseudospectral_grids/setup_grids.py
+++ b/grid_lib/pseudospectral_grids/setup_grids.py
@@ -1,0 +1,195 @@
+"""
+Setup functions for pseudospectral grids.
+
+Provides convenient interfaces for creating different types of pseudospectral grids.
+"""
+
+import numpy as np
+from typing import Optional, Union, Dict, Any
+
+from .sinc_dvr import SincDVR
+from .gauss_legendre_lobatto import GaussLegendreLobatto, Linear_map, Rational_map
+from .femdvr import FEMDVR
+
+
+def setup_grid(
+    grid_type: str,
+    grid_params: Optional[Dict[str, Any]] = None,
+) -> Union[SincDVR, GaussLegendreLobatto, FEMDVR]:
+    """Set up a pseudospectral grid of the specified type.
+
+    Parameters
+    ----------
+    grid_type : str
+        Type of grid to create. Options: 'sinc', 'gll', 'femdvr'
+    grid_params : dict, optional
+        Grid-specific parameters. See notes for details on each grid type.
+
+    Returns
+    -------
+    grid : SincDVR, GaussLegendreLobatto, or FEMDVR
+        The created grid object.
+
+    Notes
+    -----
+    For 'sinc' grids, grid_params should contain:
+        - 'x0' (float): Left endpoint. Default: -10
+        - 'xN' (float): Right endpoint. Default: 10
+        - 'N' (int): Number of grid points. Default: 40
+
+    For 'gll' grids, grid_params should contain:
+        - 'N' (int): Number of grid points minus 1 (polynomial degree)
+        - 'x0' (float): Left endpoint for default linear mapping. Default: 0
+        - 'xN' (float): Right endpoint for default linear mapping. Default: 30
+        - 'Mapping' (optional): Mapping object. Default: Linear_map()
+        - 'symmetrize' (bool): Whether to symmetrize weights. Default: False
+
+    For 'femdvr' grids, grid_params should contain:
+        - 'nodes' (ndarray): Element boundary nodes
+        - 'n_points' (ndarray): Number of points per element
+        - 'Mapping' (optional): Mapping class. Default: Linear_map
+        - 'element_class' (optional): Element class. Default: GaussLegendreLobatto
+        - 'symmetrize' (bool): Whether to symmetrize. Default: False
+
+    Examples
+    --------
+    >>> # Create a sinc grid with default parameters
+    >>> grid = setup_grid('sinc')
+
+    >>> # Create a sinc grid with custom parameters
+    >>> grid = setup_grid('sinc', {'x0': -5, 'xN': 5, 'N': 50})
+
+    >>> # Create a GLL grid with 50 points
+    >>> grid = setup_grid('gll', {'N': 49})
+
+    >>> # Create a FEM-DVR grid
+    >>> nodes = np.array([-10, -5, 0, 5, 10])
+    >>> n_points = np.array([11, 11, 11, 11])
+    >>> grid = setup_grid('femdvr', {'nodes': nodes, 'n_points': n_points})
+    """
+    if grid_params is None:
+        grid_params = {}
+
+    grid_type = grid_type.lower()
+
+    if grid_type == 'sinc':
+        return _setup_sinc(grid_params)
+    elif grid_type == 'gll':
+        return _setup_gll(grid_params)
+    elif grid_type == 'femdvr':
+        return _setup_femdvr(grid_params)
+    else:
+        raise ValueError(
+            f"Unknown grid_type: {grid_type}. "
+            "Supported types are: 'sinc', 'gll', 'femdvr'"
+        )
+
+
+def _setup_sinc(params: Dict[str, Any]) -> SincDVR:
+    """Create a sinc DVR grid."""
+    x0 = params.get('x0', -10)
+    xN = params.get('xN', 10)
+    N = params.get('N', 40)
+
+    return SincDVR(x0, xN, N)
+
+
+def _setup_gll(params: Dict[str, Any]) -> GaussLegendreLobatto:
+    """Create a Gauss-Legendre-Lobatto grid."""
+    if 'N' not in params:
+        raise ValueError("'N' (polynomial degree) is required for 'gll' grid")
+
+    N = params['N']
+    x0 = params.get('x0', params.get('r_min', 0))
+    xN = params.get('xN', params.get('r_max', 30))
+    Mapping = params.get('Mapping', Linear_map(x0, xN))
+    symmetrize = params.get('symmetrize', False)
+
+    return GaussLegendreLobatto(N, Mapping, symmetrize=symmetrize)
+
+
+def _setup_femdvr(params: Dict[str, Any]) -> FEMDVR:
+    """Create a FEM-DVR grid."""
+    if 'nodes' not in params or 'n_points' not in params:
+        raise ValueError(
+            "'nodes' and 'n_points' are required for 'femdvr' grid"
+        )
+
+    nodes = params['nodes']
+    n_points = params['n_points']
+    Mapping = params.get('Mapping', Linear_map)
+    element_class = params.get('element_class', GaussLegendreLobatto)
+    symmetrize = params.get('symmetrize', False)
+
+    return FEMDVR(nodes, n_points, Mapping, element_class, symmetrize=symmetrize)
+
+
+def setup_femdvr_uniform(
+    x_min: float,
+    x_max: float,
+    n_elements: int,
+    points_per_element: int,
+    Mapping: Optional[type] = None,
+    symmetrize: bool = False,
+) -> FEMDVR:
+    """Set up a FEM-DVR grid with uniform element spacing and point distribution.
+
+    This is a convenience function for creating FEM-DVR grids where all elements
+    have the same number of grid points.
+
+    Parameters
+    ----------
+    x_min : float
+        Left endpoint of the domain
+    x_max : float
+        Right endpoint of the domain
+    n_elements : int
+        Number of elements
+    points_per_element : int
+        Number of grid points in each element (must be >= 2)
+    Mapping : type, optional
+        Mapping class to use for coordinate transformation. Default: Linear_map
+    symmetrize : bool, optional
+        Whether to symmetrize the weights. Default: False
+
+    Returns
+    -------
+    grid : FEMDVR
+        The created FEM-DVR grid object.
+
+    Raises
+    ------
+    ValueError
+        If points_per_element < 2
+
+    Examples
+    --------
+    >>> # Create a FEM-DVR grid with 3 elements and 11 points per element
+    >>> grid = setup_femdvr_uniform(-10, 10, 3, 11)
+
+    >>> # Create with rational mapping
+    >>> from grid_lib.pseudospectral_grids import Rational_map
+    >>> grid = setup_femdvr_uniform(-10, 100, 5, 15, Mapping=Rational_map)
+    """
+    if points_per_element < 2:
+        raise ValueError("points_per_element must be >= 2")
+
+    if Mapping is None:
+        Mapping = Linear_map
+
+    # Create uniform element boundaries
+    nodes = np.linspace(x_min, x_max, n_elements + 1)
+
+    # Create uniform point distribution across all elements
+    n_points = np.full(n_elements, points_per_element, dtype=int)
+
+    return setup_grid(
+        'femdvr',
+        {
+            'nodes': nodes,
+            'n_points': n_points,
+            'Mapping': Mapping,
+            'element_class': GaussLegendreLobatto,
+            'symmetrize': symmetrize,
+        },
+    )


### PR DESCRIPTION
Summary:
- Adds reusable setup helpers for pseudospectral grids.
- Exposes setup helpers from the pseudospectral_grids package namespace.
- Adds an example that builds multiple grids, plots $f(x) = e^{-x^2}$, and evaluates quadrature integrals against the exact Gaussian integral sqrt(pi).

What changed:
- Added grid_lib/pseudospectral_grids/setup_grids.py:
  - setup_grid for sinc, gll, and femdvr grids
  - setup_femdvr_uniform convenience constructor
  - mapping and element-class support for flexible construction
- Updated grid_lib/pseudospectral_grids/__init__.py:
  - exports Rational_map
  - exports setup_grid and setup_femdvr_uniform from setup_grids
- Added examples/setup_different_grids.py:
  - configures Sinc DVR, GLL, FEM-DVR, and uniform FEM-DVR grids
  - plots $f(x) = e^{-x^2}$ on each grid in one multi-subplot figure
  - computes quadrature via $sum_i w_i f(x_i)$
  - compares numerical values to the exact full-domain integral $\int_{-\infty}^{\infty} e^{-x^2}dx = \sqrt{\pi}$