### PR TITLE
Add Grid1D convenience class, tests, and 1D plotting example

### DIFF
--- a/examples/grid_1d_gaussian_plot.py
+++ b/examples/grid_1d_gaussian_plot.py
@@ -1,0 +1,77 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+from grid_lib.pseudospectral_grids import Grid1D
+
+
+def main() -> None:
+    x_min = -5.0
+    x_max = 5.0
+
+    grids = [
+        (
+            "Sinc",
+            Grid1D(
+                (
+                    "sinc",
+                    {
+                        "x0": x_min,
+                        "xN": x_max,
+                        "N": 121,
+                    },
+                )
+            ),
+        ),
+        (
+            "GLL",
+            Grid1D(
+                (
+                    "gll",
+                    {
+                        "N": 80,
+                        "x0": x_min,
+                        "xN": x_max,
+                        "symmetrize": False,
+                        "remove_boundaries": False,
+                    },
+                )
+            ),
+        ),
+        (
+            "FEMDVR Uniform",
+            Grid1D(
+                (
+                    "femdvr_uniform",
+                    {
+                        "x_min": x_min,
+                        "x_max": x_max,
+                        "n_elements": 8,
+                        "points_per_element": 16,
+                        "symmetrize": False,
+                        "remove_boundaries": False,
+                    },
+                )
+            ),
+        ),
+    ]
+
+    fig, axes = plt.subplots(1, 3, figsize=(14, 4), constrained_layout=True)
+
+    for ax, (label, grid) in zip(axes, grids):
+        x = grid.x
+        y = np.exp(-(x**2))
+
+        ax.plot(x, y, "o-", lw=1.2, ms=3, label=r"$e^{-x^2}$")
+        ax.set_title(label)
+        ax.set_xlabel("x")
+        ax.set_ylabel("f(x)")
+        ax.set_xlim(x_min, x_max)
+        ax.grid(True, alpha=0.3)
+        ax.legend(loc="best")
+
+    fig.suptitle("f(x) = exp(-x^2) on 1D Grids over [-5, 5]")
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/grid_lib/cartesian_coordinates/potentials.py
+++ b/grid_lib/cartesian_coordinates/potentials.py
@@ -14,6 +14,19 @@ def Coulomb(x, Z, x_c=0.0, alpha=1.0):
     return -Z / np.sqrt((x - x_c) ** 2 + alpha)
 
 
+class SoftCoreCoulomb:
+
+    def __init__(self, Z1=-1.0, Z2=-1.0, x_c=0.0, a=1.0):
+        self.Z1 = Z1
+        self.Z2 = Z2
+        self.x_c = x_c
+        if a <= 0:
+            raise ValueError("The regularization parameter must be positive.")
+        self.a = a
+
+    def __call__(self, x):
+        return self.Z1 * self.Z2 / np.sqrt((x - self.x_c) ** 2 + self.a**2)
+
 class Molecule1D:
     def __init__(self, R=[0.0], Z=[1], alpha=1.0):
         """
@@ -40,5 +53,26 @@ class Molecule1D:
         return potential
 
 
-def harmonic_oscillator(x, omega):
-    return 0.5 * omega**2 * x**2
+class HarmonicOscillator:
+    def __init__(self, omega=1.0, x_c=0.0):
+        self.omega = omega
+        self.x_c = x_c
+
+    def __call__(self, x):
+        return 0.5 * self.omega**2 * (x - self.x_c)**2
+
+def harmonic_oscillator(x, omega, x_c=0.0):
+    return 0.5 * omega**2 * (x - x_c)**2
+
+def soft_core_Coulomb(x, Z1=-1.0, Z2=-1.0, x_c=0.0, a=1.0):
+    """
+    Coulomb potential in 1D.
+
+    Args:
+        x (np.ndarray): The grid points.
+        Z1 (float): Charge of the first particle.
+        Z2 (float): Charge of the second particle.
+        x_c (float): The nuclear position.
+        a (float): The regularization parameter.
+    """
+    return Z1 * Z2 / np.sqrt((x - x_c) ** 2 + a**2)

--- a/grid_lib/pseudospectral_grids/__init__.py
+++ b/grid_lib/pseudospectral_grids/__init__.py
@@ -2,6 +2,7 @@ from .femdvr import FEMDVR
 from .sinc_dvr import SincDVR
 from .gauss_legendre_lobatto import GaussLegendreLobatto, Linear_map, Rational_map
 from .setup_grids import setup_grid, setup_femdvr_uniform
+from .grid_1d import GridBasis1D, Grid1D
 
 __all__ = [
 	"FEMDVR",
@@ -11,4 +12,6 @@ __all__ = [
 	"Rational_map",
 	"setup_grid",
 	"setup_femdvr_uniform",
+	"GridBasis1D",
+	"Grid1D",
 ]

--- a/grid_lib/pseudospectral_grids/grid_1d.py
+++ b/grid_lib/pseudospectral_grids/grid_1d.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+import numpy as np
+
+from .setup_grids import setup_femdvr_uniform, setup_grid
+
+GridBasis1D = Literal["sinc", "gll", "femdvr", "femdvr_uniform"]
+
+
+class Grid1D:
+    """Convenience wrapper for one-dimensional pseudospectral grids.
+
+    Parameters
+    ----------
+    grid
+        Tuple of (grid_basis, grid_params). Supported grid bases are
+        "sinc", "gll", "femdvr", and "femdvr_uniform".
+
+    Notes
+    -----
+    If "remove_boundaries" is provided in grid_params, it is applied only to
+    non-sinc grids and defaults to True.
+    """
+
+    valid_grid_bases = {"sinc", "gll", "femdvr", "femdvr_uniform"}
+
+    def __init__(
+        self,
+        grid: tuple[GridBasis1D, dict[str, Any]],
+    ) -> None:
+        grid_basis, grid_params = grid
+
+        self.grid_basis = grid_basis
+        self.grid_params = dict(grid_params)
+        self.remove_boundaries = self._pop_remove_boundaries()
+
+        self._validate_grid_basis()
+        self.grid = self._setup_grid()
+        self.x, self.weights, self.D1, self.D2 = self._extract_grid_arrays()
+        self.n_grid = self.x.size
+        self.dx = self._compute_dx()
+
+    def _validate_grid_basis(self) -> None:
+        if self.grid_basis not in self.valid_grid_bases:
+            valid = ", ".join(sorted(self.valid_grid_bases))
+            raise ValueError(
+                f"Unknown grid_basis {self.grid_basis!r}. "
+                f"Supported grid bases are: {valid}."
+            )
+
+    def _pop_remove_boundaries(self) -> bool:
+        return bool(self.grid_params.pop("remove_boundaries", True))
+
+    def _setup_grid(self):
+        if self.grid_basis == "femdvr_uniform":
+            params = self._normalized_femdvr_uniform_params()
+            return setup_femdvr_uniform(**params)
+
+        return setup_grid(self.grid_basis, self.grid_params)
+
+    def _normalized_femdvr_uniform_params(self) -> dict[str, Any]:
+        params = dict(self.grid_params)
+
+        required = {"x_min", "x_max", "n_elements", "points_per_element"}
+        missing = required.difference(params)
+        if missing:
+            missing_keys = ", ".join(sorted(missing))
+            raise ValueError(
+                "femdvr_uniform grid_params missing required keys: "
+                f"{missing_keys}."
+            )
+
+        params.setdefault("symmetrize", False)
+        return params
+
+    def _extract_grid_arrays(
+        self,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        if self.grid_basis == "sinc":
+            x = np.asarray(self.grid.x)
+            weights = np.asarray(self.grid.weights)
+            D1 = np.asarray(self.grid.D1)
+            D2 = np.asarray(self.grid.D2)
+        else:
+            x = np.asarray(self.grid.r)
+            weights = np.asarray(self.grid.weights)
+            D1 = np.asarray(self.grid.D1)
+            D2 = np.asarray(self.grid.D2)
+
+            if self.remove_boundaries:
+                x = x[1:-1]
+                weights = weights[1:-1]
+                D1 = D1[1:-1, 1:-1]
+                D2 = D2[1:-1, 1:-1]
+
+        self._validate_grid_arrays(x, weights, D1, D2)
+        return x, weights, D1, D2
+
+    @staticmethod
+    def _validate_grid_arrays(
+        x: np.ndarray,
+        weights: np.ndarray,
+        D1: np.ndarray,
+        D2: np.ndarray,
+    ) -> None:
+        if x.ndim != 1:
+            raise ValueError("Grid points must be a one-dimensional array.")
+        if weights.shape != x.shape:
+            raise ValueError("Grid weights must have the same shape as x.")
+        if D1.shape != (x.size, x.size):
+            raise ValueError("D1 must have shape (n_grid, n_grid).")
+        if D2.shape != (x.size, x.size):
+            raise ValueError("D2 must have shape (n_grid, n_grid).")
+        if x.size < 2:
+            raise ValueError("Grid must contain at least two points.")
+
+    def _compute_dx(self) -> float:
+        return float(self.x[1] - self.x[0])
+
+
+__all__ = ["GridBasis1D", "Grid1D"]

--- a/tests/test_grid_1d.py
+++ b/tests/test_grid_1d.py
@@ -1,0 +1,55 @@
+import numpy as np
+import pytest
+
+from grid_lib.pseudospectral_grids import Grid1D
+
+
+def test_system_grid_1d_sinc_shapes():
+    system = Grid1D(("sinc", {"x0": -1.0, "xN": 1.0, "N": 11}))
+
+    assert system.x.shape == (11,)
+    assert system.weights.shape == (11,)
+    assert system.D1.shape == (11, 11)
+    assert system.D2.shape == (11, 11)
+
+
+def test_system_grid_1d_gll_boundary_trimming():
+    with_boundaries = Grid1D(("gll", {"N": 6, "x0": 0.0, "xN": 2.0, "remove_boundaries": False}))
+    without_boundaries = Grid1D(("gll", {"N": 6, "x0": 0.0, "xN": 2.0, "remove_boundaries": True}))
+
+    assert without_boundaries.n_grid == with_boundaries.n_grid - 2
+    assert without_boundaries.D1.shape[0] == with_boundaries.D1.shape[0] - 2
+
+
+def test_system_grid_1d_femdvr_uniform_matches_expected_size():
+    system = Grid1D(
+        (
+            "femdvr_uniform",
+            {
+                "x_min": -2.0,
+                "x_max": 2.0,
+                "n_elements": 2,
+                "points_per_element": 4,
+            },
+        )
+    )
+
+    # FEM-DVR has shared endpoints across neighboring elements.
+    n_total = 2 * (4 - 1) + 1
+    assert system.grid.r.size == n_total
+    assert system.n_grid == n_total - 2
+
+
+def test_system_grid_1d_rejects_invalid_basis():
+    with pytest.raises(ValueError, match="Unknown grid_basis"):
+        Grid1D(("invalid", {}))
+
+
+def test_system_grid_1d_validates_required_uniform_keys():
+    with pytest.raises(ValueError, match="missing required keys"):
+        Grid1D(("femdvr_uniform", {"x_min": -1.0, "x_max": 1.0}))
+
+
+def test_system_grid_1d_dx_for_uniform_sinc_grid():
+    system = Grid1D(("sinc", {"x0": 0.0, "xN": 2.0, "N": 5}))
+    assert np.isclose(system.dx, 0.5)


### PR DESCRIPTION
This PR adds a new 1D convenience API for pseudospectral grids and provides both tests and a runnable example.

## Motivation
Creating 1D grids currently requires using low-level setup functions directly and manually normalizing output arrays across grid types. This PR introduces a single wrapper class that exposes a consistent interface for `sinc`, `gll`, `femdvr`, and `femdvr_uniform`.

## What changed
- Added new `Grid1D` class and `GridBasis1D` type alias in grid_lib/pseudospectral_grids/grid_1d.py.
- Exported `Grid1D` and `GridBasis1D` from grid_lib/pseudospectral_grids/__init__.py.
- Added focused tests in tests/test_grid_1d.py covering:
1. Shape consistency for `sinc`.
2. Boundary trimming behavior for `gll`.
3. `femdvr_uniform` point-count expectations.
4. Invalid grid basis validation.
5. Required-parameter validation.
6. `dx` sanity check.
- Added usage example in examples/grid_1d_gaussian_plot.py that creates `sinc`, `gll`, and `femdvr_uniform` grids on `[-5, 5]` and plots $f(x)=e^{-x^2}$.
- Resolved a merge-conflict artifact in grid_lib/cartesian_coordinates/potentials.py by keeping both `Coulomb` function behavior and `SoftCoreCoulomb` class availability.

## API notes
- New public import:
`from grid_lib.pseudospectral_grids import Grid1D`
- `Grid1D` exposes commonly used attributes:
`x`, `weights`, `D1`, `D2`, `n_grid`, `dx`.